### PR TITLE
fixed selected visualization name

### DIFF
--- a/dashboards-observability/public/components/custom_panels/panel_modules/visualization_flyout/visualization_flyout.tsx
+++ b/dashboards-observability/public/components/custom_panels/panel_modules/visualization_flyout/visualization_flyout.tsx
@@ -239,6 +239,7 @@ export const VisaulizationFlyout = ({
               hasNoInitialSelection
               onChange={(e) => onChangeSelection(e)}
               options={visualizationOptions}
+              value={selectValue}
             />
           </EuiFormRow>
           <EuiSpacer size="l" />


### PR DESCRIPTION
Signed-off-by: Vishal Kushwah <vishal.kushwah@domo.com>

### Description
Visualization Name doesn't appear in selected visualization field in Operational Panel #1101

### Issues Resolved
https://github.com/opensearch-project/observability/issues/1101

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
